### PR TITLE
Kill StoRM webdav as same user that created it.

### DIFF
--- a/teapot.py
+++ b/teapot.py
@@ -405,7 +405,7 @@ async def _stop_webdav_instance(username):
 
     if pid:
         logger.info(f"Stopping webdav instance with PID {pid}.")
-        kill_proc = subprocess.Popen(f"sudo kill {pid}", shell=True)
+        kill_proc = subprocess.Popen(f"sudo -u {username} kill {pid}", shell=True)
         kill_exit_code = kill_proc.wait()
         if kill_exit_code != 0:
             # what now?


### PR DESCRIPTION
Motivation:

teapot will shutdown the StoRM WebDAV service as user root.  This is unnecessary, as the targeted user is able to stop the StoRM WebDAV service.

In general, running operations as root should be avoided.

Also, not requiring root makes it simpler to run teapot as a single user (in a development environment).

Modification:

Update sudo command to target the targeted user.

Result:

teapot no longer makes use of root access to shutdown StoRM webdav.