### PR TITLE
Remove non-python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-java-11
-openssl>3.0
-python3
 fastapi
 flaat
 httpx
@@ -11,3 +8,4 @@ uvicorn
 anyio
 asyncio
 psutil
+


### PR DESCRIPTION
Motivation:

The `requirements.txt` file is used by python tools (pip, in particular) to describe the python dependencies.

The file current contains non-Python dependencies, which confuses these Python tools.

Modification:

Remove non-Python dependencies from the `requirements.txt` file.

Result:

The `pip install .` command now functions correctly.

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
