### PR TITLE
certificate verification fixed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     needs: [build, containerization]
     runs-on: ubuntu-latest
     container:
-      image: dvrbanec/main:1
+      image: dvrbanec/main:latest
     services:
       keycloak:
         image: dvrbanec/keycloak-dev:latest

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,10 +31,10 @@ user should be on a single line, separated by a single space.
 
 To configure the OIDC provider information, make the following changes:
 
-1. Modify the OIDC provider in `issuers.yml` by changing the `name` and `issuer`
+1. Modify the OIDC provider in `issuers` by changing the `name` and `issuer`
    information.
-2. Modify the OIDC provider in `storage_authorizations.yml` by modifying the
-   `iss` information which stands for issuer.
+2. Modify the OIDC provider in `storage_authorizations` by modifying the `iss`
+   information which stands for issuer.
 3. Modify the OIDC providers that have access to the storage area by modifying
    the `org` information in `storage_element.properties`.
 4. Modify the OIDC provider list in `teapot.py` under

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -13,7 +13,7 @@ RUN \
     rpm -i teapot-v*.noarch.rpm --nodeps
 
 WORKDIR /etc/pki/ca-trust/source/anchors
-ADD --chmod=744 https://syncandshare.desy.de/index.php/s/2X6TbWWFR6Dq59K/download/teapot.pem .
+ADD --chmod=744 https://syncandshare.desy.de/index.php/s/KY8ARPLQHzw2Fdm/download/Teapot-testing.crt .
 ADD --chmod=744 https://syncandshare.desy.de/index.php/s/Xb8djtiyXPrGboG/download/testingCA.pem .
 RUN update-ca-trust 
 

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -5,6 +5,7 @@
 # trunk-ignore-all(hadolint/DL3007)
 FROM dvrbanec/teapot-requirements:latest
 
+RUN pip install ssl
 # installing Teapot
 WORKDIR /tmp
 COPY teapot-v*.noarch.rpm .

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -20,7 +20,7 @@ RUN update-ca-trust
 # certificates
 WORKDIR /var/lib/teapot/webdav/
 ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/2X6TbWWFR6Dq59K/download/teapot.pem .
-ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/H9HZZWpbPFFHgx5/download/teapot.key .
+ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/QSDidypFNFyCk96/download/teapot-key.pem .
 
 # configuring teapot for testing
 WORKDIR /etc/teapot

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -14,14 +14,13 @@ RUN \
 
 WORKDIR /etc/pki/ca-trust/source/anchors
 ADD --chmod=744 https://syncandshare.desy.de/index.php/s/KY8ARPLQHzw2Fdm/download/Teapot-testing.crt .
-ADD --chmod=744 https://syncandshare.desy.de/index.php/s/Xb8djtiyXPrGboG/download/testingCA.pem .
 ADD --chmod=744 https://syncandshare.desy.de/index.php/s/TfosBEAmNnMRQtL/download/localhost.crt .
 RUN update-ca-trust 
 
 # certificates
 WORKDIR /var/lib/teapot/webdav/
-ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/GoCe4PWFJ5s95tP/download/teapot.crt .
-ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/H9HZZWpbPFFHgx5/download/teapot.key .
+ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/AT4LMp9qJ3yxs9x/download/teapot.crt .
+ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/zY6agLE29TAtkke/download/teapot.key .
 ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/TfosBEAmNnMRQtL/download/localhost.crt .
 ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/Z4xFNWMCCq4KRFm/download/localhost.key .
 

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -15,12 +15,15 @@ RUN \
 WORKDIR /etc/pki/ca-trust/source/anchors
 ADD --chmod=744 https://syncandshare.desy.de/index.php/s/KY8ARPLQHzw2Fdm/download/Teapot-testing.crt .
 ADD --chmod=744 https://syncandshare.desy.de/index.php/s/Xb8djtiyXPrGboG/download/testingCA.pem .
+ADD --chmod=744 https://syncandshare.desy.de/index.php/s/TfosBEAmNnMRQtL/download/localhost.crt .
 RUN update-ca-trust 
 
 # certificates
 WORKDIR /var/lib/teapot/webdav/
-ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/2X6TbWWFR6Dq59K/download/teapot.pem .
-ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/QSDidypFNFyCk96/download/teapot-key.pem .
+ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/GoCe4PWFJ5s95tP/download/teapot.crt .
+ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/H9HZZWpbPFFHgx5/download/teapot.key .
+ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/TfosBEAmNnMRQtL/download/localhost.crt .
+ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/Z4xFNWMCCq4KRFm/download/localhost.key .
 
 # configuring teapot for testing
 WORKDIR /etc/teapot

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -13,13 +13,13 @@ RUN \
     rpm -i teapot-v*.noarch.rpm --nodeps
 
 WORKDIR /etc/pki/ca-trust/source/anchors
-ADD --chmod=744 https://syncandshare.desy.de/index.php/s/KY8ARPLQHzw2Fdm/download/Teapot-testing.crt .
-ADD --chmod=744 https://syncandshare.desy.de/index.php/s/37RZn84eNtDGJDX/download/testingCA.crt .
+ADD --chmod=744 https://syncandshare.desy.de/index.php/s/2X6TbWWFR6Dq59K/download/teapot.pem .
+ADD --chmod=744 https://syncandshare.desy.de/index.php/s/Xb8djtiyXPrGboG/download/testingCA.pem .
 RUN update-ca-trust 
 
 # certificates
 WORKDIR /var/lib/teapot/webdav/
-ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/GoCe4PWFJ5s95tP/download/teapot.crt .
+ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/2X6TbWWFR6Dq59K/download/teapot.pem .
 ADD --chown=teapot --chmod=644 https://syncandshare.desy.de/index.php/s/H9HZZWpbPFFHgx5/download/teapot.key .
 
 # configuring teapot for testing

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -5,7 +5,6 @@
 # trunk-ignore-all(hadolint/DL3007)
 FROM dvrbanec/teapot-requirements:latest
 
-RUN pip install ssl
 # installing Teapot
 WORKDIR /tmp
 COPY teapot-v*.noarch.rpm .

--- a/robot/compose/docker-compose.yml
+++ b/robot/compose/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     networks:
       - test
   main:
-    image: dvrbanec/main:1
+    image: dvrbanec/main:latest
     command: |
       /bin/sh -c '
       eval "$(oidc-agent)"

--- a/robot/compose/docker-compose.yml
+++ b/robot/compose/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       curl -O https://syncandshare.desy.de/index.php/s/EmKsQpW67LapT3z/download/teapot-tests.robot
       curl -O https://syncandshare.desy.de/index.php/s/rWYXp7tdCMbfJA8/download/variables.py
       robot --outputdir robot/output/ /tmp/teapot-tests.robot
-      echo "Debugging 2"
+      echo "Debugging 3"
       while true; do sleep 1; done'
     networks:
       - test

--- a/robot/main.dockerfile
+++ b/robot/main.dockerfile
@@ -7,7 +7,7 @@ RUN apt update && \
 
 WORKDIR /usr/local/share/ca-certificates
 ADD https://syncandshare.desy.de/index.php/s/KY8ARPLQHzw2Fdm/download/Teapot-testing.crt .
-ADD https://syncandshare.desy.de/index.php/s/37RZn84eNtDGJDX/download/testingCA.crt .
+# ADD https://syncandshare.desy.de/index.php/s/37RZn84eNtDGJDX/download/testingCA.crt .
 RUN update-ca-certificates
 
 RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/kitrepo-archive.gpg] https://repo.data.kit.edu//ubuntu/22.04 ./" >> /etc/apt/sources.list && \

--- a/robot/main.dockerfile
+++ b/robot/main.dockerfile
@@ -7,11 +7,14 @@ RUN apt update && \
 
 WORKDIR /usr/local/share/ca-certificates
 ADD https://syncandshare.desy.de/index.php/s/KY8ARPLQHzw2Fdm/download/Teapot-testing.crt .
-# ADD https://syncandshare.desy.de/index.php/s/37RZn84eNtDGJDX/download/testingCA.crt .
 RUN update-ca-certificates
+
+WORKDIR /usr/local/lib/python3.10/dist-packages/certifi/
+RUN \
+    rm -f cacert.pem && \
+    ln -s /etc/ssl/certs/ca-certificates.crt cacert.pem
 
 RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/kitrepo-archive.gpg] https://repo.data.kit.edu//ubuntu/22.04 ./" >> /etc/apt/sources.list && \
     echo "deb [signed-by=/etc/apt/trusted.gpg.d/kitrepo-archive.gpg] https://repo.data.kit.edu//ubuntu/jammy ./" >> /etc/apt/sources.list
 
 RUN apt -y install oidc-agent
-

--- a/robot/main.dockerfile
+++ b/robot/main.dockerfile
@@ -7,7 +7,7 @@ RUN apt update && \
 
 WORKDIR /usr/local/share/ca-certificates
 ADD https://syncandshare.desy.de/index.php/s/KY8ARPLQHzw2Fdm/download/Teapot-testing.crt .
-ADD https://syncandshare.desy.de/index.php/s/37RZn84eNtDGJDX/download/testingCA.crt .
+ADD https://syncandshare.desy.de/index.php/s/Xb8djtiyXPrGboG/download/testingCA.pem .
 RUN update-ca-certificates
 
 RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/kitrepo-archive.gpg] https://repo.data.kit.edu//ubuntu/22.04 ./" >> /etc/apt/sources.list && \

--- a/robot/main.dockerfile
+++ b/robot/main.dockerfile
@@ -7,7 +7,7 @@ RUN apt update && \
 
 WORKDIR /usr/local/share/ca-certificates
 ADD https://syncandshare.desy.de/index.php/s/KY8ARPLQHzw2Fdm/download/Teapot-testing.crt .
-ADD https://syncandshare.desy.de/index.php/s/Xb8djtiyXPrGboG/download/testingCA.pem .
+ADD https://syncandshare.desy.de/index.php/s/37RZn84eNtDGJDX/download/testingCA.crt .
 RUN update-ca-certificates
 
 RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/kitrepo-archive.gpg] https://repo.data.kit.edu//ubuntu/22.04 ./" >> /etc/apt/sources.list && \

--- a/robot/teapot-requirements.dockerfile
+++ b/robot/teapot-requirements.dockerfile
@@ -27,3 +27,5 @@ WORKDIR /usr/local/lib/python3.12/site-packages/certifi/
 RUN \
     rm -f cacert.pem && \
     ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem cacert.pem
+
+USER nobody

--- a/robot/teapot-requirements.dockerfile
+++ b/robot/teapot-requirements.dockerfile
@@ -17,10 +17,10 @@ WORKDIR /usr/local/ssl
 RUN ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem cert.pem
 
 WORKDIR /etc/pki/ca-trust/source/anchors
-ADD https://letsencrypt.org/certs/isrgrootx1.pem .
-ADD https://letsencrypt.org/certs/lets-encrypt-r3.pem .
-ADD http://crl.usertrust.com/USERTrustRSACertificationAuthority.crl .
-ADD http://crt.usertrust.com/USERTrustRSAAddTrustCA.crt .
+ADD  --chmod=744 https://letsencrypt.org/certs/isrgrootx1.pem .
+ADD  --chmod=744 https://letsencrypt.org/certs/lets-encrypt-r3.pem .
+ADD  --chmod=744 http://crl.usertrust.com/USERTrustRSACertificationAuthority.crl .
+ADD  --chmod=744 http://crt.usertrust.com/USERTrustRSAAddTrustCA.crt .
 RUN update-ca-trust 
 
 WORKDIR /usr/local/lib/python3.12/site-packages/certifi/

--- a/robot/teapot-tests.robot
+++ b/robot/teapot-tests.robot
@@ -5,148 +5,148 @@ Variables        /__w/teapot/teapot/robot/variables.py
 
 *** Keywords ***
 
-Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
+Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}      expected_status=201
 
-Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
+Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}      expected_status=201
 
-Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}      expected_status=204
 
-Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}      expected_status=204
 
-Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}      expected_status=204
 
-Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}      expected_status=204
 
 
-Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
+Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}      expected_status=201
 
-Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
+Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}      expected_status=201
 
-Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}      expected_status=204
 
-Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}      expected_status=204
 
-Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}      expected_status=204
 
-Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}      expected_status=204
 
 *** Test Cases ***
 
 GET USER1
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER1}     expected_status=200
 
 GET USER2
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER2}     expected_status=200
 
 GET NO TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}                          verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=403 
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}                           expected_status=403 
 
 GET INVALID TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=401
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER3}     expected_status=401
 
 
 PUT REQUEST INVALID TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=401
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}      expected_status=401
 
 PUT REQUEST NO TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=403
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                            expected_status=403
 
 PUT REQUEST USER1
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}      expected_status=201
     [Teardown]    Delete Test File1 USER1
 
 PUT REQUEST USER2
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}      expected_status=201
     [Teardown]    Delete Test File1 USER2
 
 
 GET FILE USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}     expected_status=200
     [Teardown]    Delete Test File2 USER1
 
 GET FILE USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}     expected_status=200
     [Teardown]    Delete Test File2 USER2
 
 GET FILE NO TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2                          verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=403
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2                           expected_status=403
 
 GET FILE INVALID TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=401
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}     expected_status=401
 
 
 DELETE REQUEST USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}      expected_status=204
 
 DELETE REQUEST USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}      expected_status=204
 
 DELETE REQUEST INVALID TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=401
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}      expected_status=401
 
 DELETE REQUEST NO TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=403
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                            expected_status=403
 
 
 GET USER1 EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER1}     expected_status=200
 
 GET USER2 EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER2}     expected_status=200
 
 GET NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}                          verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=403 
+    ${RESPONSE}=    GET    ${EXTRA_AREA}                           expected_status=403 
 
 GET INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=401
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER3}     expected_status=401
 
 
 PUT REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=401
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}      expected_status=401
 
 PUT REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=403
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                            expected_status=403
 
 PUT REQUEST USER1 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}      expected_status=201
     [Teardown]    Delete Test File1 USER1 EXTRA AREA
 
 PUT REQUEST USER2 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}      expected_status=201
     [Teardown]    Delete Test File1 USER2 EXTRA AREA
 
 
 GET FILE USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}     expected_status=200
     [Teardown]    Delete Test File2 USER1 EXTRA AREA
 
 GET FILE USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}     expected_status=200
     [Teardown]    Delete Test File2 USER2 EXTRA AREA
 
 GET FILE NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2                          verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=403 
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2                           expected_status=403 
 
 GET FILE INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=401
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}     expected_status=401
 
 
 DELETE REQUEST USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}      expected_status=204
 
 DELETE REQUEST USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}      expected_status=204
 
 DELETE REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=401
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}      expected_status=401
 
 DELETE REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=403
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                            expected_status=403

--- a/robot/teapot-tests.robot
+++ b/robot/teapot-tests.robot
@@ -5,148 +5,148 @@ Variables        /__w/teapot/teapot/robot/variables.py
 
 *** Keywords ***
 
-Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
+Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
 
-Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
+Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
 
-Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
-Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
-Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
-Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
 
-Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
+Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
 
-Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
+Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
 
-Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
-Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
-Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
-Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
 *** Test Cases ***
 
 GET USER1
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
 
 GET USER2
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
 
 GET NO TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}                          verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=403 
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}                          verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=403 
 
 GET INVALID TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=401
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=401
 
 
 PUT REQUEST INVALID TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=401
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=401
 
 PUT REQUEST NO TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=403
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=403
 
 PUT REQUEST USER1
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
     [Teardown]    Delete Test File1 USER1
 
 PUT REQUEST USER2
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
     [Teardown]    Delete Test File1 USER2
 
 
 GET FILE USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
     [Teardown]    Delete Test File2 USER1
 
 GET FILE USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
     [Teardown]    Delete Test File2 USER2
 
 GET FILE NO TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2                          verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=403
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2                          verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=403
 
 GET FILE INVALID TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=401
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=401
 
 
 DELETE REQUEST USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
 DELETE REQUEST USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
 DELETE REQUEST INVALID TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=401
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=401
 
 DELETE REQUEST NO TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=403
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=403
 
 
 GET USER1 EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
 
 GET USER2 EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
 
 GET NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}                          verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=403 
+    ${RESPONSE}=    GET    ${EXTRA_AREA}                          verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=403 
 
 GET INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=401
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=401
 
 
 PUT REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=401
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=401
 
 PUT REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=403
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=403
 
 PUT REQUEST USER1 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
     [Teardown]    Delete Test File1 USER1 EXTRA AREA
 
 PUT REQUEST USER2 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
     [Teardown]    Delete Test File1 USER2 EXTRA AREA
 
 
 GET FILE USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
     [Teardown]    Delete Test File2 USER1 EXTRA AREA
 
 GET FILE USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
     [Teardown]    Delete Test File2 USER2 EXTRA AREA
 
 GET FILE NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2                          verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=403 
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2                          verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=403 
 
 GET FILE INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=401
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=401
 
 
 DELETE REQUEST USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
 DELETE REQUEST USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
 
 DELETE REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=401
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=401
 
 DELETE REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=403
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=403

--- a/robot/teapot-tests.robot
+++ b/robot/teapot-tests.robot
@@ -5,30 +5,30 @@ Variables        /__w/teapot/teapot/robot/variables.py
 
 *** Keywords ***
 
-Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify=${false}     expected_status=201
+Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    expected_status=201
 
-Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify=${false}     expected_status=201
+Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    expected_status=201
 
-Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    verify=${false}     expected_status=204
+Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    expected_status=204
 
-Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    verify=${false}     expected_status=204
+Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    expected_status=204
 
-Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify=${false}     expected_status=204
+Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    expected_status=204
 
-Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify=${false}     expected_status=204
+Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    expected_status=204
 
 
-Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify=${false}     expected_status=201
+Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    expected_status=201
 
-Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify=${false}     expected_status=201
+Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    expected_status=201
 
-Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    verify=${false}     expected_status=204
+Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    expected_status=204
 
-Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    verify=${false}     expected_status=204
+Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    expected_status=204
 
-Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify=${false}     expected_status=204
+Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    expected_status=204
 
-Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify=${false}     expected_status=204
+Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    expected_status=204
 
 *** Test Cases ***
 
@@ -46,17 +46,17 @@ GET INVALID TOKEN
 
 
 PUT REQUEST INVALID TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify=${false}     expected_status=401
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    expected_status=401
 
 PUT REQUEST NO TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          verify=${false}     expected_status=403
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          expected_status=403
 
 PUT REQUEST USER1
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify=${false}     expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    expected_status=201
     [Teardown]    Delete Test File1 USER1
 
 PUT REQUEST USER2
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify=${false}     expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    expected_status=201
     [Teardown]    Delete Test File1 USER2
 
 
@@ -79,17 +79,17 @@ GET FILE INVALID TOKEN
 
 DELETE REQUEST USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify=${false}     expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    expected_status=204
 
 DELETE REQUEST USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify=${false}     expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    expected_status=204
 
 DELETE REQUEST INVALID TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify=${false}     expected_status=401
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    expected_status=401
 
 DELETE REQUEST NO TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          verify=${false}     expected_status=403
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          expected_status=403
 
 
 GET USER1 EXTRA_AREA
@@ -106,17 +106,17 @@ GET INVALID TOKEN EXTRA_AREA
 
 
 PUT REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify=${false}     expected_status=401
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    expected_status=401
 
 PUT REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          verify=${false}     expected_status=403
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          expected_status=403
 
 PUT REQUEST USER1 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify=${false}     expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    expected_status=201
     [Teardown]    Delete Test File1 USER1 EXTRA AREA
 
 PUT REQUEST USER2 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify=${false}     expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    expected_status=201
     [Teardown]    Delete Test File1 USER2 EXTRA AREA
 
 
@@ -139,14 +139,14 @@ GET FILE INVALID TOKEN EXTRA_AREA
 
 DELETE REQUEST USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify=${false}     expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    expected_status=204
 
 DELETE REQUEST USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify=${false}     expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    expected_status=204
 
 DELETE REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify=${false}     expected_status=401
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    expected_status=401
 
 DELETE REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          verify=${false}     expected_status=403
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          expected_status=403

--- a/robot/teapot-tests.robot
+++ b/robot/teapot-tests.robot
@@ -5,148 +5,148 @@ Variables        /__w/teapot/teapot/robot/variables.py
 
 *** Keywords ***
 
-Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    expected_status=201
+Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
 
-Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    expected_status=201
+Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
 
-Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    expected_status=204
+Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
-Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    expected_status=204
+Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
-Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    expected_status=204
+Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
-Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    expected_status=204
+Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
 
-Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    expected_status=201
+Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
 
-Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    expected_status=201
+Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
 
-Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    expected_status=204
+Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
-Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    expected_status=204
+Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
-Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    expected_status=204
+Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
-Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    expected_status=204
+Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
 *** Test Cases ***
 
 GET USER1
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER1}    verify=${false}    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
 
 GET USER2
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER2}    verify=${false}    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
 
 GET NO TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}                          verify=${false}    expected_status=403 
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}                          verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=403 
 
 GET INVALID TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER3}    verify=${false}    expected_status=401
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=401
 
 
 PUT REQUEST INVALID TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    expected_status=401
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=401
 
 PUT REQUEST NO TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          expected_status=403
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=403
 
 PUT REQUEST USER1
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
     [Teardown]    Delete Test File1 USER1
 
 PUT REQUEST USER2
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
     [Teardown]    Delete Test File1 USER2
 
 
 GET FILE USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify=${false}    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
     [Teardown]    Delete Test File2 USER1
 
 GET FILE USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify=${false}    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
     [Teardown]    Delete Test File2 USER2
 
 GET FILE NO TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2                          verify=${false}    expected_status=403
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2                          verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=403
 
 GET FILE INVALID TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify=${false}    expected_status=401
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=401
 
 
 DELETE REQUEST USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
 DELETE REQUEST USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
 DELETE REQUEST INVALID TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    expected_status=401
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=401
 
 DELETE REQUEST NO TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          expected_status=403
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=403
 
 
 GET USER1 EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER1}    verify=${false}    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
 
 GET USER2 EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER2}    verify=${false}    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
 
 GET NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}                          verify=${false}    expected_status=403 
+    ${RESPONSE}=    GET    ${EXTRA_AREA}                          verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=403 
 
 GET INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER3}    verify=${false}    expected_status=401
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=401
 
 
 PUT REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    expected_status=401
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=401
 
 PUT REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          expected_status=403
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=403
 
 PUT REQUEST USER1 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
     [Teardown]    Delete Test File1 USER1 EXTRA AREA
 
 PUT REQUEST USER2 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=201
     [Teardown]    Delete Test File1 USER2 EXTRA AREA
 
 
 GET FILE USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify=${false}    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
     [Teardown]    Delete Test File2 USER1 EXTRA AREA
 
 GET FILE USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify=${false}    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=200
     [Teardown]    Delete Test File2 USER2 EXTRA AREA
 
 GET FILE NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2                          verify=${false}    expected_status=403 
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2                          verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=403 
 
 GET FILE INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify=${false}    expected_status=401
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"    expected_status=401
 
 
 DELETE REQUEST USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
 DELETE REQUEST USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=204
 
 DELETE REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    expected_status=401
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=401
 
 DELETE REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          expected_status=403
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          verify="/usr/local/share/ca-certificates/testingCA.pem"     expected_status=403

--- a/robot/teapot-tests.robot
+++ b/robot/teapot-tests.robot
@@ -5,148 +5,148 @@ Variables        /__w/teapot/teapot/robot/variables.py
 
 *** Keywords ***
 
-Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
+Add Test File USER1     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
 
-Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
+Add Test File USER2     ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
 
-Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+Delete Test File1 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
-Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+Delete Test File1 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile1    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
-Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+Delete Test File2 USER1     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
-Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+Delete Test File2 USER2     ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
 
-Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
+Add Test File USER1 EXTRA AREA    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
 
-Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
+Add Test File USER2 EXTRA AREA     ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile2    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
 
-Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+Delete Test File1 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
-Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+Delete Test File1 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile1    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
-Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+Delete Test File2 USER1 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
-Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+Delete Test File2 USER2 EXTRA AREA     ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
 *** Test Cases ***
 
 GET USER1
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
 
 GET USER2
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
 
 GET NO TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}                          verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=403 
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}                          verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=403 
 
 GET INVALID TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=401
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=401
 
 
 PUT REQUEST INVALID TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=401
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=401
 
 PUT REQUEST NO TOKEN
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=403
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}                          verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=403
 
 PUT REQUEST USER1
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
     [Teardown]    Delete Test File1 USER1
 
 PUT REQUEST USER2
-    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
+    ${RESPONSE}=    PUT    ${DEFAULT_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
     [Teardown]    Delete Test File1 USER2
 
 
 GET FILE USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
     [Teardown]    Delete Test File2 USER1
 
 GET FILE USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
     [Teardown]    Delete Test File2 USER2
 
 GET FILE NO TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2                          verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=403
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2                          verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=403
 
 GET FILE INVALID TOKEN
-    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=401
+    ${RESPONSE}=    GET    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=401
 
 
 DELETE REQUEST USER1
     [Setup]     Add Test File USER1
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
 DELETE REQUEST USER2
     [Setup]     Add Test File USER2
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
 DELETE REQUEST INVALID TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=401
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=401
 
 DELETE REQUEST NO TOKEN
-    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=403
+    ${RESPONSE}=    DELETE    ${DEFAULT_AREA}/TestFile2                          verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=403
 
 
 GET USER1 EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
 
 GET USER2 EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
 
 GET NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}                          verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=403 
+    ${RESPONSE}=    GET    ${EXTRA_AREA}                          verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=403 
 
 GET INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=401
+    ${RESPONSE}=    GET    ${EXTRA_AREA}    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=401
 
 
 PUT REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=401
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=401
 
 PUT REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=403
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}                          verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=403
 
 PUT REQUEST USER1 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
     [Teardown]    Delete Test File1 USER1 EXTRA AREA
 
 PUT REQUEST USER2 EXTRA_AREA
-    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=201
+    ${RESPONSE}=    PUT    ${EXTRA_AREA}/TestFile1    data=${DATA}    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=201
     [Teardown]    Delete Test File1 USER2 EXTRA AREA
 
 
 GET FILE USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
     [Teardown]    Delete Test File2 USER1 EXTRA AREA
 
 GET FILE USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=200
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=200
     [Teardown]    Delete Test File2 USER2 EXTRA AREA
 
 GET FILE NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2                          verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=403 
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2                          verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=403 
 
 GET FILE INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"    expected_status=401
+    ${RESPONSE}=    GET    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"    expected_status=401
 
 
 DELETE REQUEST USER1 EXTRA_AREA
     [Setup]     Add Test File USER1 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER1}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
 DELETE REQUEST USER2 EXTRA_AREA
     [Setup]     Add Test File USER2 EXTRA AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=204
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER2}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=204
 
 DELETE REQUEST INVALID TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=401
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2    headers=${HEADER3}    verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=401
 
 DELETE REQUEST NO TOKEN EXTRA_AREA
-    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          verify="/etc/ssl/certs/ca-certificates.crt"     expected_status=403
+    ${RESPONSE}=    DELETE    ${EXTRA_AREA}/TestFile2                          verify="/etc/ssl/certs/Teapot-testing.pem"     expected_status=403

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient(verify="/var/lib/teapot/webdav/teapot.pem")
+client = httpx.AsyncClient(cert="/var/lib/teapot/webdav/teapot.pem")
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient()
+client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchorstestingCA.pem")
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -15,6 +15,7 @@ from os.path import exists
 from pwd import getpwnam
 from stat import *
 
+import ssl
 import anyio
 import httpx
 import psutil
@@ -110,7 +111,9 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient(verify=False)
+context = ssl.create_default_context()
+context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/testingCA.pem ")
+client = httpx.AsyncClient(verify=context)
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -112,7 +112,7 @@ app.state.session_state = {}
 app.state.state_lock = anyio.Lock()
 
 context = ssl.create_default_context()
-context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/testingCA.pem")
+context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/Teapot-testing.crt")
 client = httpx.AsyncClient(verify=context)
 
 

--- a/teapot.py
+++ b/teapot.py
@@ -626,7 +626,9 @@ async def _return_or_create_storm_instance(sub):
                 logger.debug(
                     f"checking if instance for user {local_user} is listening on port {port}."
                 )
-                resp = httpx.get(f"https://localhost:{port}/")
+                context1 = ssl.create_default_context()
+                context1.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/localhost.crt")
+                resp = httpx.get(f"https://localhost:{port}/", verify=context1)
                 if resp.status_code >= 200:
                     running = True
             except httpx.ConnectError:

--- a/teapot.py
+++ b/teapot.py
@@ -111,9 +111,9 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-#context = ssl.create_default_context()
-#context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/testingCA.pem")
-client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchors/testingCA.pem")
+context = ssl.create_default_context()
+context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/testingCA.pem")
+client = httpx.AsyncClient(verify=context)
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -9,13 +9,13 @@ import logging
 import os
 import pathlib
 import socket
+import ssl
 import subprocess
 from contextlib import asynccontextmanager
 from os.path import exists
 from pwd import getpwnam
-from stat import *
+from stat import S_IRGRP, S_IRWXO, S_IRWXU, S_IXGRP
 
-import ssl
 import anyio
 import httpx
 import psutil
@@ -77,30 +77,38 @@ logging.basicConfig(filename=LOGFILE, level=logging.getLevelName(LOGLEVEL))
 logger = logging.getLogger(__name__)
 
 # globals
-# TODO: load globals via config file on startup and reload on every run of stop_expired_instances,
+# TODO: load globals via config file on startup and reload on every
+# run of stop_expired_instances,
 # maybe rename function to "housekeeping" or the like.
 
 SESSION_STORE_PATH = os.environ.get(
     "TEAPOT_SESSIONS", "/var/lib/teapot/webdav/teapot_sessions.json"
 )
 APP_NAME = "teapot"
-# one less than the first port that is going to be used by any storm webdav instance, should be above 1024
-# as all ports below this are privileged and normal users will not be able to use them to run services.
+# one less than the first port that is going to be used by any
+# storm webdav instance, should be above 1024
+# as all ports below this are privileged and normal users will
+# not be able to use them to run services.
 STARTING_PORT = 32399
-# toggle restarting teapot without deleting saved state and without terminating running webdav instances.
+# toggle restarting teapot without deleting saved state and without
+# terminating running webdav instances.
 # N.B. will only consider the value set at startup of this app.
 RESTART = os.environ.get("TEAPOT_RESTART", "False") == "True"
-# instance timeout, instances are deleted after this time without being accessed.
+# instance timeout, instances are deleted after this time without
+# being accessed.
 # default: 10 minutes
 INSTANCE_TIMEOUT_SEC = 600
 # interval between instance timeout checks in stop_expired_instances
 # default: 3 minutes
 CHECK_INTERVAL_SEC = 180
-# number of times that teapot will try to connect to a recently started instance
+# number of times that teapot will try to connect to a recently
+# started instance
 STARTUP_TIMEOUT = int(os.environ.get("TEAPOT_STARTUP_TIMEOUT", 30))
 # standard mode for file creation, currently rwxr-x---
-# directories and files are created with the corresponding os.mkdir, os.chmod, os.chown commands.
-# those are using the bit patterns provided with the 'stat' module as below, combining them happens via bitwise OR
+# directories and files are created with the corresponding
+# os.mkdir, os.chmod, os.chown commands.
+# those are using the bit patterns provided with the 'stat'
+# module as below, combining them happens via bitwise OR
 # TODO: find a way to not have to use rwx for others!
 STANDARD_MODE = S_IRWXU | S_IRGRP | S_IXGRP | S_IRWXO
 # session state is kept in this global dict for each username as primary key
@@ -112,7 +120,9 @@ app.state.session_state = {}
 app.state.state_lock = anyio.Lock()
 
 context = ssl.create_default_context()
-context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/Teapot-testing.crt")
+context.load_verify_locations(
+    cafile="/etc/pki/ca-trust/source/anchors/Teapot-testing.crt"
+)
 client = httpx.AsyncClient(verify=context)
 
 
@@ -123,16 +133,18 @@ async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):
         except FileExistsError:
             # this info msg should never be triggered, right?
             logger.error(
-                f"Directory {dir} already exists, therefore this message should not exist. Something is wrong..."
+                f"Directory {dir} already exists, therefore this message"
+                + " should not exist. Something is wrong..."
             )
         try:
             os.chmod(dir, mode)
-        except:
+        except OSError:
             logger.error(f"Could not chmod directory {dir} to {mode}.")
         # try:
         #    os.chown(dir, uid, gid)
         # except PermissionError:
-        #    logger.error(f"Could not chown directory {dir}, not allowed to change ownership to {uid}, {gid}.")
+        #    logger.error(f"Could not chown directory {dir}, not allowed to
+        # change ownership to {uid}, {gid}.")
 
 
 async def _create_user_dirs(username):
@@ -146,18 +158,23 @@ async def _create_user_dirs(username):
     # - /etc/APP_NAME/storage-areas
     # - /etc/APP_NAME/user-mapping.csv
 
-    logger.debug(f"creating user dirs...")
+    logger.debug("creating user dirs...")
     config_dir = f"/etc/{APP_NAME}"
     if not exists(f"{config_dir}/storage-areas"):
         logger.error(
-            f"{config_dir}/storage-areas is missing. It should consist of two variables per storage area: name of the storage area and root path to the storage area's directory separated by a single space."
+            f"{config_dir}/storage-areas is missing. It should consist of two "
+            + "variables per storage area: name of the storage area and root "
+            + "path to the storage area's directory separated by a single "
+            + "space."
         )
         return False
 
     mapping_file = f"{config_dir}/user-mapping.csv"
     if not exists(mapping_file):
         logger.error(
-            f"{mapping_file} does not exist. It should consist of two variables per user: username and subject claim separated by a single space."
+            f"{mapping_file} does not exist. It should consist of two "
+            + "variables per user: username and subject claim separated "
+            + "by a single space."
         )
         return False
 
@@ -192,20 +209,23 @@ async def _create_user_dirs(username):
     for dir in dirs_to_create:
         await makedir_chown_chmod(dir, uid, gid)
 
-    with open(f"/usr/share/{APP_NAME}/storage_element.properties", "r") as prop:
+    with open(f"/usr/share/{APP_NAME}/storage_element.properties",
+              "r") as prop:
         second_part = prop.readlines()
     with open(f"{config_dir}/storage-areas", "r") as storage_areas:
         for line in storage_areas:
             storage_area, path = line.split(" ")
             path_components = path.split("/")
-            # check for different paths in storage-areas that need to be corrected.
             if path_components[0] == "$HOME":
                 path_components[0] = f"/home/{username}"
             path = os.path.join(*path_components)
             sa_properties_path = f"{user_sa_d_dir}/{storage_area}.properties"
             if not exists(sa_properties_path):
                 with open(sa_properties_path, "w") as storage_area_properties:
-                    first_part = f"name={storage_area}\nrootPath={path}\naccessPoints=/{storage_area}_area\n\n"
+                    first_part = (
+                        f"name={storage_area}\nrootPath={path}"
+                        + f"\naccessPoints=/{storage_area}_area\n\n"
+                    )
                     storage_area_properties.write(first_part)
                     for line in second_part:
                         storage_area_properties.write(line)
@@ -223,7 +243,8 @@ async def _create_user_dirs(username):
             issuers_part = issuers.readlines()
         with open("/usr/share/teapot/storage_authorizations", "r") as auths:
             authorization_part = "".join(auths.readlines())
-        with open(f"{user_config_dir}/application.yml", "a") as application_yml:
+        with open(f"{user_config_dir}/application.yml",
+                  "a") as application_yml:
             for line in issuers_part:
                 application_yml.write(line)
             application_yml.write("storm:\n  authz:\n    policies:\n")
@@ -299,19 +320,25 @@ async def _start_webdav_instance(username, port):
         return False
 
     # as a dict for subprocess.Popen
-    # env_pass = {key: value for key,value in os.environ.items() if key.startswith("STORM_WEBDAV_")}
+    # env_pass = {key: value for key,value in os.environ.items() if
+    # key.startswith("STORM_WEBDAV_")}
 
-    # add STORM_WEBDAV_* env vars to a list that can be passed to the sudo command and be preserved for the forked process
-    env_pass = [key for key in os.environ.keys() if key.startswith("STORM_WEBDAV_")]
+    # add STORM_WEBDAV_* env vars to a list that can be passed to the sudo
+    # command and be preserved for the forked process
+    env_pass = [key for key in os.environ.keys()
+                if key.startswith("STORM_WEBDAV_")]
 
     # starting subprocess with all necessary options now.
-    # using os.setsid() as a function handle before execution should execute the process in it's own process group
+    # using os.setsid() as a function handle before execution should execute
+    # the process in it's own process group
     # such that it can be managed on its own.
     logger.info(f"trying to start process for user {username}.")
-    full_cmd = f"sudo --preserve-env={','.join(env_pass)} -u {username} /usr/bin/java -jar $STORM_WEBDAV_JAR $STORM_WEBDAV_JVM_OPTS \
+    full_cmd = f"sudo --preserve-env={','.join(env_pass)} -u {username} \
+    /usr/bin/java -jar $STORM_WEBDAV_JAR $STORM_WEBDAV_JVM_OPTS \
     -Djava.io.tmpdir=/var/lib/user-{username}/tmp \
     -Dlogging.config=$STORM_WEBDAV_LOG_CONFIGURATION \
-    --spring.config.additional-location=optional:file:/var/lib/{APP_NAME}/user-{username}/config/application.yml \
+    --spring.config.additional-location= \
+    optional:file:/var/lib/{APP_NAME}/user-{username}/config/application.yml \
      1>$STORM_WEBDAV_OUT 2>$STORM_WEBDAV_ERR &"
 
     logger.info(f"full_cmd={full_cmd}")
@@ -320,16 +347,19 @@ async def _start_webdav_instance(username, port):
 
     # wait for it...
     await anyio.sleep(1)
-    # poll the process to get rid of the zombiefied subprocess attached to teapot
+    # poll the process to get rid of the zombiefied subprocess attached
+    # to teapot
     p.poll()
 
-    # get rid of additional whitespace, trailing "&" and output redirects from cmdline, expand env vars
+    # get rid of additional whitespace, trailing "&" and output redirects from
+    # cmdline, expand env vars
     full_cmd = " ".join(full_cmd.split())[:-1]
     full_cmd = " ".join(full_cmd.split(","))
     full_cmd = os.path.expandvars(full_cmd)
     full_cmd = full_cmd.split("1>")[0].rstrip()
 
-    # we can remove all env vars for the user process from teapot now as they were given to the forked process as a copy
+    # we can remove all env vars for the user process from teapot now as they
+    # were given to the forked process as a copy
     await _remove_user_env()
 
     # get the process pid for terminating it later.
@@ -338,12 +368,14 @@ async def _start_webdav_instance(username, port):
     # check process status and store the handle.
     if kill_proc.status() in [psutil.STATUS_RUNNING, psutil.STATUS_SLEEPING]:
         logger.debug(
-            f"start_webdav_instance: instance for user {username} is running under PID {kill_proc.pid}."
+            f"start_webdav_instance: instance for user {username}"
+            + f" is running under PID {kill_proc.pid}."
         )
         return kill_proc.pid
     else:
         logger.error(
-            f"_start_webdav_instance: instance for user {username} could not be started. pid was {kill_proc.pid}."
+            f"_start_webdav_instance: instance for user {username}"
+            + f" could not be started. pid was {kill_proc.pid}."
         )
         # if there was a returncode, we wait for the process and terminate it.
         kill_proc.wait()
@@ -351,12 +383,14 @@ async def _start_webdav_instance(username, port):
 
 
 async def _get_proc(full_cmd):
-    # here we are simply looking through all processes and try to find a match for the full command
-    # that was issued to start the instance in question. then return the process handle.
-    # it should contain the process that is running as root and forked the storm instance for
-    # the user themselves.
-    # looking through all processes seems a bit overkill but at the moment this is the only
-    # halfway surefire method I could find to accomplish this task.
+    # here we are simply looking through all processes and try to find a
+    # match for the full command that was issued to start the instance in
+    # question. then return the process handle.
+    # it should contain the process that is running as root and forked
+    # the storm instance for the user themselves.
+    # looking through all processes seems a bit overkill but at the moment
+    # this is the only halfway surefire method I could find to accomplish
+    # this task.
     # shamelessly stolen from
     # https://codereview.stackexchange.com/questions/183091/start-a-sub-process-with-sudo-as-head-of-new-process-group-kill-it-after-time
     for pid in psutil.pids():
@@ -364,33 +398,41 @@ async def _get_proc(full_cmd):
         if full_cmd == " ".join(proc.cmdline()):
             logger.info(f"PID found: {pid}")
             return proc
-    raise RuntimeError(f"process with for full command {full_cmd} does not exist.")
+    raise RuntimeError(f"process with for full command {full_cmd} "
+                       + "does not exist.")
 
 
 async def _stop_webdav_instance(username):
     logger.info(f"Stopping webdav instance for user {username}.")
 
     logger.debug(
-        f"_stop_webdav_instance: trying to acquire lock at {datetime.datetime.now().isoformat()}"
+        "_stop_webdav_instance: trying to acquire lock at "
+        + f"{datetime.datetime.now().isoformat()}"
     )
     async with app.state.state_lock:
         logger.debug(
-            f"_stop_webdav_instance: acquired lock at {datetime.datetime.now().isoformat()}"
+            "_stop_webdav_instance: acquired lock at "
+            + f"{datetime.datetime.now().isoformat()}"
         )
         try:
             session = app.state.session_state.pop(username)
         except KeyError:
             logger.error(
-                f"_stop_webdav_instance: session state for user {username} doesn't exist."
+                f"_stop_webdav_instance: session state for user {username}"
+                + "doesn't exist."
             )
             return -1
 
-    # first naive workaround will be to just give sudo rights to teapot for /usr/bin/kill
+    # first naive workaround will be to just give sudo rights to teapot for
+    # /usr/bin/kill
     # TODO: find a safer way to accomplish this!
-    # originally wanted to kill the process via os.killpg but the storm process is running under the user's uid, so that is not possible
+    # originally wanted to kill the process via os.killpg but the storm
+    # process is running under the user's uid, so that is not possible
     # os.killpg(os.getpgid(p.pid), signal.SIGTERM)
-    # now we run subprocess.Popen in the user context to let it terminate the process in that user's context.
-    # but as we don't want to let teapot be able to just kill any process (by sudoers mechanism), we need to find a way around this,
+    # now we run subprocess.Popen in the user context to let it terminate
+    # the process in that user's context.
+    # but as we don't want to let teapot be able to just kill any process
+    # (by sudoers mechanism), we need to find a way around this,
     # maybe with a dedicated script that can only kill certain processes?
 
     pid = session.get("pid", "None")
@@ -418,21 +460,25 @@ async def stop_expired_instances():
         await asyncio.sleep(CHECK_INTERVAL_SEC)
         logger.info("checking for expired instances")
         logger.debug(
-            f"stop_expired_instances: trying to acquire 'users' lock at {datetime.datetime.now().isoformat()}"
+            "stop_expired_instances: trying to acquire 'users' lock at "
+            + f"{datetime.datetime.now().isoformat()}"
         )
         async with app.state.state_lock:
             logger.debug(
-                f"stop_expired_instances: acquired 'users' lock at {datetime.datetime.now().isoformat()}"
+                "stop_expired_instances: acquired 'users' lock at "
+                + f"{datetime.datetime.now().isoformat()}"
             )
             users = list(app.state.session_state.keys())
         now = datetime.datetime.now()
         for user in users:
             logger.debug(
-                f"stop_expired_instances: trying to acquire 'user_dict' lock at {datetime.datetime.now().isoformat()}"
+                "stop_expired_instances: trying to acquire 'user_dict' "
+                + f"lock at {datetime.datetime.now().isoformat()}"
             )
             async with app.state.state_lock:
                 logger.debug(
-                    f"stop_expired_instances: acquired 'user_dict' lock at {datetime.datetime.now().isoformat()}"
+                    "stop_expired_instances: acquired 'user_dict' lock at "
+                    + f"{datetime.datetime.now().isoformat()}"
                 )
                 user_dict = app.state.session_state.get(user, None)
             if user_dict is not None:
@@ -444,41 +490,49 @@ async def stop_expired_instances():
                         # TODO: remove instance from session_state
                         if res != 0:
                             logger.error(
-                                f"Instance for user {user} exited with code {res}."
+                                f"Instance for user {user} exited with code "
+                                + f"{res}."
                             )
                         else:
                             logger.info(
-                                f"Instance for user {user} has been terminated after timeout."
+                                f"Instance for user {user} has been terminated"
+                                + " after timeout."
                             )
                 else:
                     logger.error(
-                        f"_stop_expired_instances: Session for user {user} does not have the property 'last_accessed'."
+                        f"_stop_expired_instances: Session for user {user} "
+                        + "does not have the property 'last_accessed'."
                     )
             else:
                 logger.error(
-                    f"_stop_expired_instances: No session object for user {user} in session_state."
+                    "_stop_expired_instances: No session object for user "
+                    + f"{user} in session_state."
                 )
 
 
 async def _find_usable_port_no():
     used_ports = []
     logger.debug(
-        f"_find_usable_port_no: trying to acquire lock at {datetime.datetime.now().isoformat()}"
+        "_find_usable_port_no: trying to acquire lock at "
+        + f"{datetime.datetime.now().isoformat()}"
     )
     async with app.state.state_lock:
         logger.debug(
-            f"_find_usable_port_no: acquired lock at {datetime.datetime.now().isoformat()}"
+            "_find_usable_port_no: acquired lock at "
+            + f"{datetime.datetime.now().isoformat()}"
         )
         users = app.state.session_state.keys()
         if users:
             for user in users:
                 tmp_port = app.state.session_state[user].get("port", None)
                 logger.debug(
-                    f"find_usable_port_no: use {user} has an instance running on port {tmp_port}."
+                    f"find_usable_port_no: use {user} has an instance running "
+                    f" on port {tmp_port}."
                 )
                 used_ports.append(tmp_port)
         else:
-            # if there are no instances running yet, we want the ports to start from 32400
+            # if there are no instances running yet, we want the ports to
+            # start from 32400
             logger.debug(f"no port in use by teapot, using {STARTING_PORT}")
             used_ports = [STARTING_PORT]
 
@@ -488,7 +542,8 @@ async def _find_usable_port_no():
             port = await _test_port(max_used)
         else:
             logger.error(
-                "Missing port number for running instances, can not determine fitting port number."
+                "Missing port number for running instances, can not determine "
+                + "fitting port number."
             )
             port = None
             # should not happen :grimacing:
@@ -536,13 +591,17 @@ async def load_session_state():
 
 async def _map_fed_to_local(sub):
     # this func returns the local username for a federated user or None
-    # for this prototype it could just be read from a mapping file on the local file system.  # noqa: E501
-    # in this naive implementation, it is expected that the mapping file has the format
+    # for this prototype it could just be read from a mapping file on the
+    # local file system.
+    # in this naive implementation, it is expected that the mapping file has
+    # the format
     #
     #   federated-sub-claim,local-username
     #
-    # without headers and only the first hit for a federated sub claim is returned.
-    # like this, it is possible to match different subs to a local username but not the other way around.  # noqa: E501
+    # without headers and only the first hit for a federated sub claim is
+    # returned.
+    # like this, it is possible to match different subs to a local username but
+    # not the other way around.
 
     with open("/etc/teapot/user-mapping.csv", "r") as mapping_file:
         mappingreader = csv.reader(mapping_file, delimiter=" ")
@@ -566,38 +625,49 @@ async def _return_or_create_storm_instance(sub):
     # now check if an instance is running by checking the global state
     if local_user in app.state.session_state.keys():
         logger.debug(
-            f"_return_or_create_storm_instance: trying to acquire 'get' lock at {datetime.datetime.now().isoformat()}"
+            "_return_or_create_storm_instance: trying to acquire 'get' lock "
+            + f"at {datetime.datetime.now().isoformat()}"
         )
         async with app.state.state_lock:
             logger.debug(
-                f"_return_or_create_storm_instance: acquired 'get' lock at {datetime.datetime.now().isoformat()}"
+                "_return_or_create_storm_instance: acquired 'get' lock "
+                + f"at {datetime.datetime.now().isoformat()}"
             )
             port = app.state.session_state[local_user].get("port", None)
             app.state.session_state[local_user]["last_accessed"] = str(
                 datetime.datetime.now()
             )
-        logger.info(
-            f"StoRM-WebDAV instance for {local_user} is running on port {port}."
-        )  # noqa: E501
+        logger.info(f"StoRM-WebDAV instance for {local_user} is running on "
+                    + f"port {port}")
     else:
-        # if no instance is running, start it. but first, it has to be checked if the directories exist, if not, they need to be created.
-        # also, we need to write the env vars into a .bash_profile for the user, so they are there when the webdav-instance is started.
-        # the port, pid, storage_area and directory will be managed within an sqlite database here in teapot.
-        # no external scripts anymore to keep the state and its management in one place.
-        logger.debug(f"no instance running for user {local_user} yet, starting now.")
+        # if no instance is running, start it. but first, it has to be checked
+        # if the directories exist, if not, they need to be created.
+        # also, we need to write the env vars into a .bash_profile for the
+        # user, so they are there when the webdav-instance is started.
+        # the port, pid, storage_area and directory will be managed within an
+        # sqlite database here in teapot.
+        # no external scripts anymore to keep the state and its management in
+        # one place.
+        logger.debug(
+            f"no instance running for user {local_user} yet, "
+            + "starting now."
+        )
         port = await _find_usable_port_no()
         pid = await _start_webdav_instance(local_user, port)
         if not pid:
             logger.error(
-                f"something went wrong while starting instance for user {local_user}."
+                "something went wrong while starting instance for user "
+                + f"{local_user}."
             )
             return None, -1, local_user
         logger.debug(
-            f"_return_or_create_storm_instance: trying to acquire 'set' lock at {datetime.datetime.now().isoformat()}"
+            "_return_or_create_storm_instance: trying to acquire 'set' lock "
+            + f"at {datetime.datetime.now().isoformat()}"
         )
         async with app.state.state_lock:
             logger.debug(
-                f"_return_or_create_storm_instance: acquired 'set' lock at {datetime.datetime.now().isoformat()}"
+                "_return_or_create_storm_instance: acquired 'set' lock "
+                + f"at {datetime.datetime.now().isoformat()}"
             )
             app.state.session_state[local_user] = {
                 "pid": pid,
@@ -611,33 +681,43 @@ async def _return_or_create_storm_instance(sub):
             await anyio.sleep(1)
             if loops >= STARTUP_TIMEOUT:
                 logger.info(
-                    f"instance for user {local_user} not reachable after {STARTUP_TIMEOUT} tries... stop trying."
+                    f"instance for user {local_user} not reachable after "
+                    + f"{STARTUP_TIMEOUT} tries... stop trying."
                 )
                 logger.debug(
-                    f"_return_or_create_storm_instance: trying to acquire 'pop' lock at {datetime.datetime.now().isoformat()}"
+                    "_return_or_create_storm_instance: trying to acquire "
+                    + f"'pop' lock at {datetime.datetime.now().isoformat()}"
                 )
                 async with app.state.state_lock:
                     logger.debug(
-                        f"_return_or_create_storm_instance: acquired 'pop' lock at {datetime.datetime.now().isoformat()}"
+                        "_return_or_create_storm_instance: acquired 'pop' "
+                        + f"lock at {datetime.datetime.now().isoformat()}"
                     )
                     app.state.session_state.pop(local_user)
                 return None, -1, local_user
             try:
                 logger.debug(
-                    f"checking if instance for user {local_user} is listening on port {port}."
+                    f"checking if instance for user {local_user} is listening "
+                    + f"on port {port}."
                 )
                 context1 = ssl.create_default_context()
-                context1.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/localhost.crt")
+                context1.load_verify_locations(
+                    cafile="/etc/pki/ca-trust/source/anchors/localhost.crt"
+                )
                 resp = httpx.get(f"https://localhost:{port}/", verify=context1)
                 if resp.status_code >= 200:
                     running = True
             except httpx.ConnectError:
                 loops += 1
                 logger.debug(
-                    f"_return_or_create: trying to reach instance, try {loops}/{STARTUP_TIMEOUT}..."
+                    "_return_or_create: trying to reach instance, try "
+                    + f"{loops}/{STARTUP_TIMEOUT}..."
                 )
 
-        logger.info(f"Storm-WebDAV instance for {local_user} started on port {port}.")
+        logger.info(
+            f"Storm-WebDAV instance for {local_user} started on port "
+            + f"{port}."
+        )
     return None, port, local_user
 
 
@@ -673,11 +753,11 @@ async def root(
         # if there is no sub, user can not be authenticated
         raise HTTPException(status_code=403)
     # user is valid, so check if a storm instance is running for this sub
-    redirect_host, redirect_port, local_user = await _return_or_create_storm_instance(
-        sub
-    )
+    redirect_host, redirect_port, local_user = \
+        await _return_or_create_storm_instance(sub)
 
-    # REVISIT: should these errors be thrown from _return_or_create_storm_instance?
+    # REVISIT: should these errors be thrown from
+    # _return_or_create_storm_instance?
     if not redirect_host and not redirect_port:
         # no mapping between federated and local user identity found
         raise HTTPException(status_code=403)
@@ -691,7 +771,8 @@ async def root(
         )
     if not redirect_host:
         redirect_host = "localhost"
-    logger.info(f"redirect_host: {redirect_host}, redirect_port: {redirect_port}")
+    logger.info(f"redirect_host: {redirect_host}, redirect_port: "
+                + f"{redirect_port}")
     logger.info(f"request path: {request.url.path}")
 
     redirect_url = f"https://{redirect_host}:{redirect_port}{request.url.path}"
@@ -717,7 +798,8 @@ def main():
     key = "/var/lib/teapot/webdav/teapot.key"
     cert = "/var/lib/teapot/webdav/teapot.crt"
 
-    uvicorn.run(app, host="teapot", port=8081, ssl_keyfile=key, ssl_certfile=cert)
+    uvicorn.run(app, host="teapot", port=8081, ssl_keyfile=key,
+                ssl_certfile=cert)
 
 
 if __name__ == "__main__":

--- a/teapot.py
+++ b/teapot.py
@@ -251,8 +251,8 @@ async def _create_user_env(username, port):
     os.environ["STORM_WEBDAV_SERVER_ADDRESS"] = "localhost"
     os.environ["STORM_WEBDAV_HTTPS_PORT"] = f"{port}"
     os.environ["STORM_WEBDAV_HTTP_PORT"] = f"{port+1}"
-    os.environ["STORM_WEBDAV_CERTIFICATE_PATH"] = f"{storm_dir}/teapot.pem"
-    os.environ["STORM_WEBDAV_PRIVATE_KEY_PATH"] = f"{storm_dir}/teapot-key.pem"
+    os.environ["STORM_WEBDAV_CERTIFICATE_PATH"] = f"{storm_dir}/localhost.crt"
+    os.environ["STORM_WEBDAV_PRIVATE_KEY_PATH"] = f"{storm_dir}/localhost.key"
     os.environ["STORM_WEBDAV_TRUST_ANCHORS_DIR"] = "/etc/ssl/certs"
     os.environ["STORM_WEBDAV_TRUST_ANCHORS_REFRESH_INTERVAL"] = "86400"
     os.environ["STORM_WEBDAV_MAX_CONNECTIONS"] = "300"
@@ -712,8 +712,8 @@ async def root(
 
 
 def main():
-    key = "/var/lib/teapot/webdav/teapot-key.pem"
-    cert = "/var/lib/teapot/webdav/teapot.pem"
+    key = "/var/lib/teapot/webdav/teapot.key"
+    cert = "/var/lib/teapot/webdav/teapot.crt"
 
     uvicorn.run(app, host="teapot", port=8081, ssl_keyfile=key, ssl_certfile=cert)
 

--- a/teapot.py
+++ b/teapot.py
@@ -112,7 +112,7 @@ app.state.session_state = {}
 app.state.state_lock = anyio.Lock()
 
 context = ssl.create_default_context()
-context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/testingCA.pem ")
+context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/testingCA.pem")
 client = httpx.AsyncClient(verify=context)
 
 

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient(verify="/var/lib/teapot/webdav/teapot.crt")
+client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchors/testingCA.crt")
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -249,7 +249,7 @@ async def _create_user_env(username, port):
     os.environ["STORM_WEBDAV_HTTPS_PORT"] = f"{port}"
     os.environ["STORM_WEBDAV_HTTP_PORT"] = f"{port+1}"
     os.environ["STORM_WEBDAV_CERTIFICATE_PATH"] = f"{storm_dir}/teapot.pem"
-    os.environ["STORM_WEBDAV_PRIVATE_KEY_PATH"] = f"{storm_dir}/teapot.key"
+    os.environ["STORM_WEBDAV_PRIVATE_KEY_PATH"] = f"{storm_dir}/teapot-key.pem"
     os.environ["STORM_WEBDAV_TRUST_ANCHORS_DIR"] = "/etc/ssl/certs"
     os.environ["STORM_WEBDAV_TRUST_ANCHORS_REFRESH_INTERVAL"] = "86400"
     os.environ["STORM_WEBDAV_MAX_CONNECTIONS"] = "300"
@@ -709,7 +709,7 @@ async def root(
 
 
 def main():
-    key = "/var/lib/teapot/webdav/teapot.key"
+    key = "/var/lib/teapot/webdav/teapot-key.pem"
     cert = "/var/lib/teapot/webdav/teapot.pem"
 
     uvicorn.run(app, host="teapot", port=8081, ssl_keyfile=key, ssl_certfile=cert)

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchorstestingCA.pem")
+client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchors/testingCA.pem")
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,8 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient(cert="/var/lib/teapot/webdav/teapot.pem")
+cert = ("/var/lib/teapot/webdav/teapot.pem", "/var/lib/teapot/webdav/teapot-key.pem")
+client = httpx.AsyncClient(cert=cert)
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):
@@ -218,7 +219,7 @@ async def _create_user_dirs(username):
                     break
         with open(f"{config_dir}/issuers", "r") as issuers:
             issuers_part = issuers.readlines()
-        with open(f"/usr/share/teapot/storage_authorizations", "r") as auths:
+        with open("/usr/share/teapot/storage_authorizations", "r") as auths:
             authorization_part = "".join(auths.readlines())
         with open(f"{user_config_dir}/application.yml", "a") as application_yml:
             for line in issuers_part:

--- a/teapot.py
+++ b/teapot.py
@@ -626,7 +626,7 @@ async def _return_or_create_storm_instance(sub):
                 logger.debug(
                     f"checking if instance for user {local_user} is listening on port {port}."
                 )
-                resp = httpx.get(f"https://localhost:{port}/", verify=False)
+                resp = httpx.get(f"https://localhost:{port}/")
                 if resp.status_code >= 200:
                     running = True
             except httpx.ConnectError:

--- a/teapot.py
+++ b/teapot.py
@@ -111,9 +111,9 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-context = ssl.create_default_context()
-context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/testingCA.pem")
-client = httpx.AsyncClient(verify=context)
+#context = ssl.create_default_context()
+#context.load_verify_locations(cafile="/etc/pki/ca-trust/source/anchors/testingCA.pem")
+client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchors/testingCA.pem")
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchors/testingCA.crt")
+client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchors/testingCA.pem")
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient(verify="/etc/pki/ca-trust/source/anchors/testingCA.pem")
+client = httpx.AsyncClient(verify="/var/lib/teapot/webdav/teapot.pem")
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -110,8 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-cert = ("/var/lib/teapot/webdav/teapot.pem", "/var/lib/teapot/webdav/teapot-key.pem")
-client = httpx.AsyncClient(cert=cert)
+client = httpx.AsyncClient(verify=False)
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient(verify=False)
+client = httpx.AsyncClient()
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):

--- a/teapot.py
+++ b/teapot.py
@@ -110,7 +110,7 @@ app.state.session_state = {}
 # in an "async with app.state_lock:" environment.
 app.state.state_lock = anyio.Lock()
 
-client = httpx.AsyncClient()
+client = httpx.AsyncClient(verify="/var/lib/teapot/webdav/teapot.crt")
 
 
 async def makedir_chown_chmod(dir, uid, gid, mode=STANDARD_MODE):


### PR DESCRIPTION
Teapot no longer ignores certificate verification with verify=False. Now trusted CA certs are specified and teapot can verify requests. 
Robot framework no longer ignores certificate verification with verify=False. Python certifi's ca-bundle has been updated and it now recognizes teapot's ca cert.