### PR TITLE
Fixing storm webdav kill

### DIFF
--- a/teapot.py
+++ b/teapot.py
@@ -504,8 +504,9 @@ async def _stop_webdav_instance(username):
     if pid:
         logger.info("Stopping webdav instance with PID %d.", pid)
         try:
+            pid_storm = subprocess.Popen(f"grep PID /var/log/teapot/storm-webdav-server-user-{username}.out | cut -c 186- | grep -Eo "[0-9]+"")
             kill_proc = subprocess.Popen(
-                f"sudo -u {username} kill {pid}", shell=True  # trunk-ignore(bandit)
+                f"sudo -u {username} kill {pid_storm}", shell=True  # trunk-ignore(bandit)
             )  # GitHub Issue #30
             kill_exit_code = kill_proc.wait()
             if kill_exit_code != 0:

--- a/teapot.py
+++ b/teapot.py
@@ -504,7 +504,6 @@ async def _stop_webdav_instance(username):
     if pid:
         logger.info("Stopping webdav instance with PID %d.", pid)
         try:
-            # pid_storm = subprocess.Popen(f"grep PID /var/log/teapot/storm-webdav-server-user-{username}.out | cut -c 186- | grep -Eo "[0-9]+"")
             kill_proc = subprocess.Popen(
                 f"sudo kill {pid}", shell=True  # trunk-ignore(bandit)
             )  # GitHub Issue #30

--- a/teapot.py
+++ b/teapot.py
@@ -65,7 +65,7 @@ async def lifespan(app: FastAPI):
         loop = asyncio.get_event_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()
-        loop.create_task(stop_expired_instances())
+    loop.create_task(stop_expired_instances())
 
     yield
 
@@ -462,7 +462,7 @@ async def _get_proc(cmd):
         if cmd == " ".join(proc.cmdline()):
             logger.info("PID found: %d", pid)
             return proc
-    raise RuntimeError("process with for full command ", +cmd + "does not exist.")
+    raise RuntimeError("process with full command ", +cmd + "does not exist.")
 
 
 async def _stop_webdav_instance(username):
@@ -505,7 +505,7 @@ async def _stop_webdav_instance(username):
         logger.info("Stopping webdav instance with PID %d.", pid)
         try:
             kill_proc = subprocess.Popen(
-                f"sudo kill {pid}", shell=True  # trunk-ignore(bandit)
+                f"sudo /usr/bin/kill {pid}", shell=True  # trunk-ignore(bandit)
             )  # GitHub Issue #30
             kill_exit_code = kill_proc.wait()
             if kill_exit_code != 0:

--- a/teapot.py
+++ b/teapot.py
@@ -504,9 +504,9 @@ async def _stop_webdav_instance(username):
     if pid:
         logger.info("Stopping webdav instance with PID %d.", pid)
         try:
-            pid_storm = subprocess.Popen(f"grep PID /var/log/teapot/storm-webdav-server-user-{username}.out | cut -c 186- | grep -Eo "[0-9]+"")
+            # pid_storm = subprocess.Popen(f"grep PID /var/log/teapot/storm-webdav-server-user-{username}.out | cut -c 186- | grep -Eo "[0-9]+"")
             kill_proc = subprocess.Popen(
-                f"sudo -u {username} kill {pid_storm}", shell=True  # trunk-ignore(bandit)
+                f"sudo kill {pid}", shell=True  # trunk-ignore(bandit)
             )  # GitHub Issue #30
             kill_exit_code = kill_proc.wait()
             if kill_exit_code != 0:


### PR DESCRIPTION
Fixed some bugs in killing storm-webdav instances. Teapot now kills storm-webdav instances as a root. 

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
