### PR TITLE
Improved on the Teapot's response - headers and webdav

### DIFF
--- a/teapot.py
+++ b/teapot.py
@@ -7,6 +7,7 @@ import errno
 import json
 import logging
 import os
+import re
 import socket
 import ssl
 import subprocess
@@ -14,7 +15,6 @@ from contextlib import asynccontextmanager
 from os.path import exists
 from pathlib import Path
 from pwd import getpwnam
-import re
 from stat import S_IRGRP, S_IRWXO, S_IRWXU, S_IXGRP
 
 import anyio

--- a/teapot.py
+++ b/teapot.py
@@ -1016,6 +1016,7 @@ async def create_content_stream(content_bytes):
     """Create an async generator that yields the given content"""
     yield content_bytes
 
+
 def get_encoding_from_headers(headers):
     content_type = headers.get("content-type", "")
     match = re.search(r"charset=([^\s;]+)", content_type, re.IGNORECASE)
@@ -1144,7 +1145,9 @@ async def root(request: Request):
         # Recalculate length safely
         rewritten_headers["content-length"] = str(len(rewritten_content_bytes))
     else:
-        rewritten_content_bytes = await forward_resp.read()
+        rewritten_content_bytes = b""
+        async for chunk in forward_resp.aiter_bytes():
+            rewritten_content_bytes += chunk
 
     return StreamingResponse(
         create_content_stream(rewritten_content_bytes),


### PR DESCRIPTION
Improved WebDAV Response Handling in Teapot

-  Modify the hostname in WebDAV responses only for the PROPFIND request to correctly reflect the file paths.

-  Add calculation and inclusion of the Content-Length header for proper response size handling.

-  Enhance encoding support by detecting the specified encoding; if none is provided, default to UTF-8 instead of assuming it.